### PR TITLE
Merging Tile Adjacencies into Main

### DIFF
--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -16,7 +16,11 @@ public class GameManager : MonoBehaviour
         gameWorld.FillEmptyWorld(7);
         //gameWorld.PrintWorld();
         gameWorld.SetTileAdjacency();
-        gameWorld.TestTileAdjacency(0,0);
+        gameWorld.TestTileAdjacency(2,0);
         gameWorld.TestTileAdjacency(1,0);
+        gameWorld.TestTileAdjacency(3,0);
+        gameWorld.TestTileAdjacency(0,1);
+        gameWorld.TestTileAdjacency(0,2);
+        gameWorld.TestTileAdjacency(99,49);
     }
 }

--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -14,6 +14,8 @@ public class GameManager : MonoBehaviour
     {
         World gameWorld = new World(100,50);
         gameWorld.FillEmptyWorld(7);
-        gameWorld.PrintWorld();
+        //gameWorld.PrintWorld();
+        gameWorld.SetTileAdjacency();
+        gameWorld.TestTileAdjacency(1,1);
     }
 }

--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -16,6 +16,6 @@ public class GameManager : MonoBehaviour
         gameWorld.FillEmptyWorld(7);
         //gameWorld.PrintWorld();
         gameWorld.SetTileAdjacency();
-        gameWorld.TestTileAdjacency(1,1);
+        gameWorld.TestTileAdjacency(2,0);
     }
 }

--- a/Assets/Scripts/Game Manager.cs
+++ b/Assets/Scripts/Game Manager.cs
@@ -16,6 +16,7 @@ public class GameManager : MonoBehaviour
         gameWorld.FillEmptyWorld(7);
         //gameWorld.PrintWorld();
         gameWorld.SetTileAdjacency();
-        gameWorld.TestTileAdjacency(2,0);
+        gameWorld.TestTileAdjacency(0,0);
+        gameWorld.TestTileAdjacency(1,0);
     }
 }

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -56,8 +56,8 @@ public class Tile : MonoBehaviour
     private int _resource; // The resource on this Tile. Could be a specific Bonus, Luxury, Strategic Resource, or no Resource. CHECK ID INDEX ABOVE^
     private int _improvement; // The Tile Improvement on this Tile or 0 for No Improvement. CHECK ID INDEX ABOVE^
     private int _mc; // Movement cost - the amount of Movement Points a Unit must spend to move unto that Tile.
-    private Tile[] _neighbors; // Adjacent Tiles to these tiles. Index corresponds to Edge assuming flat top/bottom hexagons. Flat Top is 0, Flat Bottom is 3, Right sides are 1,2, Left Sides are 3,4.
-    private bool[] _riverAdj; // Are the Tile edges Adjacent to a river? -> [0,1,2,3,4,5] Represent edges on a hexagon starting from the Top moving clockwise.
+    private Tile[] _neighbors; // Adjacent Tiles to these tiles. Index corresponds to Edge assuming flat top/bottom hexagons. Top is 0, Bottom is 3
+    private bool[] _riverAdj; // Are the Tile edges Adjacent to a river? -> [0,1,2,3,4,5] Represent edges on a hexagon starting from the Top moving clockwise. Top is 0, Bottom is 3
     private Unit _unit; // The Unit on this Tile. May be null (no unit on Tile). 
     private Settlement _settlement; // The Settlement on this Tile. May be null (no Settlement on Tile).
     private int[] _yields; // An int array of a Tile's Yields. [Food, Production, Gold, Culture, Science] -> [0,1,2,3,4]

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -56,6 +56,7 @@ public class Tile : MonoBehaviour
     private int _resource; // The resource on this Tile. Could be a specific Bonus, Luxury, Strategic Resource, or no Resource. CHECK ID INDEX ABOVE^
     private int _improvement; // The Tile Improvement on this Tile or 0 for No Improvement. CHECK ID INDEX ABOVE^
     private int _mc; // Movement cost - the amount of Movement Points a Unit must spend to move unto that Tile.
+    private Tile[] _neighbors; // Adjacent Tiles to these tiles. Index corresponds to Edge assuming flat top/bottom hexagons. Flat Top is 0, Flat Bottom is 3, Right sides are 1,2, Left Sides are 3,4.
     private bool[] _riverAdj; // Are the Tile edges Adjacent to a river? -> [0,1,2,3,4,5] Represent edges on a hexagon starting from the Top moving clockwise.
     private Unit _unit; // The Unit on this Tile. May be null (no unit on Tile). 
     private Settlement _settlement; // The Settlement on this Tile. May be null (no Settlement on Tile).
@@ -76,6 +77,7 @@ public class Tile : MonoBehaviour
         _feature = feature;
         _resource = resource;
         _improvement = Zero;
+        _neighbors = new Tile[TileEdges];
         _unit = null;
         _settlement = null;
         _mc = CalculateMovementCost();
@@ -91,6 +93,7 @@ public class Tile : MonoBehaviour
         _feature = feature;
         _resource = resource;
         _improvement = tileImprovement;
+        _neighbors = new Tile[TileEdges];
         _unit = unit;
         _settlement = settlement;
         _riverAdj = CalculateRiverAdjacency();
@@ -341,6 +344,11 @@ public class Tile : MonoBehaviour
         _yields = CalculateYields();
     }
 
+    public void SetNeighbor(int edge, Tile neighbor)
+    {
+        _neighbors[edge] = neighbor;
+    }
+
     public void SetUnit(Unit unit)
     {
         
@@ -385,6 +393,11 @@ public class Tile : MonoBehaviour
     public int GetImprovement()
     {
         return _improvement;
+    }
+
+    public Tile[] GetNeighbors()
+    {
+        return _neighbors;
     }
 
     public int GetMovementCost()

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -25,8 +25,6 @@ public class Unit : MonoBehaviour
     private const int UnitMaxHealth = 100;
     private const int HillAttackDebuf = 10;
     private const int RiverAttackDebuf = 10;
-    
-    
 
     /* Custom Unit Constructor (For testing) */
     public Unit(string name, int movementPoints, int combatStrength, int supplies, int attackRange)

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -53,6 +53,19 @@ public class Unit : MonoBehaviour
         
     }
     
+    /* Move a Unit to one of it's adjacent tiles */
+    public void MoveOneTile(Tile nextTile)
+    {
+        if (nextTile.GetMovementCost() <= GetMovementPoints() && IsExhausted()) // Check if the Unit has enough MP and isn't exhausted
+        {
+            SetTile(nextTile);
+            SetMovementPoints(GetMovementPoints() - _tile.GetMovementCost()); // Reduce Unit's MP by tile's MC
+        }
+        
+        
+    }
+
+    
     /* Attack another Unit */
     public void Attack(Unit target)
     {

--- a/Assets/Scripts/World Generator.cs
+++ b/Assets/Scripts/World Generator.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WorldGenerator : MonoBehaviour
+{
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/World Generator.cs.meta
+++ b/Assets/Scripts/World Generator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc5bf43ce9681bd458ff71b95cd5db0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World.cs
+++ b/Assets/Scripts/World.cs
@@ -43,7 +43,7 @@ public class World : MonoBehaviour
         }
     }
 
-    /* Sets Tile Adjacency (neighbors) based on a Flat Top/Bottom hexagon  with an even-q orientation. */
+    /* Sets Tile Adjacency (neighbors) based on a Flat Top/Bottom hexagon grid with an even-q orientation (0,0 must be at bottom left of grid). */
     public void SetTileAdjacency()
     {
         for (int x = 0; x < _length; x++)
@@ -114,6 +114,7 @@ public class World : MonoBehaviour
         Debug.Log(worldString);
     }
 
+    /* Takes a Tile's X & Y Position on a 2D grid and prints a list of its neighbors' X & Y.  */
     public void TestTileAdjacency(int xPos, int yPos)
     {
         string output = "Tile ("+xPos+","+yPos+") is adjacent to: " + "\n";

--- a/Assets/Scripts/World.cs
+++ b/Assets/Scripts/World.cs
@@ -46,47 +46,63 @@ public class World : MonoBehaviour
     /* Sets Tile Adjacency (neighbors) based on a Flat Top/Bottom hexagon  with an even-q orientation. */
     public void SetTileAdjacency()
     {
-        for (int x = 0; x < _length - 1; x++)
+        // Set the first Tile's neighbor's
+        _world[0,0].SetNeighbor(0, _world[0,1]);
+        _world[0,1].SetNeighbor(3, _world[0,0]);
+        
+        _world[0,0].SetNeighbor(1, _world[1,0]);
+        _world[1,0].SetNeighbor(4, _world[0,0]);
+        
+        
+        for (int x = 0; x < _length; x++)
         {
-            for (int y = 0; y < _height - 1; y++)
+            for (int y = 0; y < _height; y++)
             {
-                // Top and Bottom of all Flat edges
-                _world[x, y].SetNeighbor(0, _world[x, y + 1]);
-                _world[x, y + 1].SetNeighbor(3, _world[x, y]);
-
-                // Check that X index is not out of bounds
-                if (x > 0 && x < _length && y > 0 && y < _height)
+                // Edge 0
+                if (y < _height - 1)
                 {
-                    // If X is Odd
-                   if (x % 2 != 0)
-                   {
-                       // Bottom Left of Odd X / Top Right of Even X
-                       _world[x, y].SetNeighbor(4, _world[x - 1, y]);
-                       _world[x - 1, y].SetNeighbor(1, _world[x, y]);
-                       
-                       // Bottom Right of Odd X / Top Left of Even X
-                       _world[x , y].SetNeighbor(2, _world[x + 1, y]);
-                       _world[x + 1, y].SetNeighbor(5, _world[x, y]);
-                   }
-                   else // If X is Even
-                   {
-                       // Top Left of Even X / Bottom Right of Odd X
-                       _world[x,y].SetNeighbor(5, _world[x - 1, y]);
-                       _world[x - 1, y].SetNeighbor(2, _world[x, y]);
-                       
-                       // Top Right of Even X / Bottom Left of Odd X
-                       _world[x,y].SetNeighbor(1, _world[x + 1, y]);
-                       _world[x + 1, y].SetNeighbor(4, _world[x, y]);
-                       
-                       // Bottom Right of Even // Top Left of Odd
-                       _world[x, y].SetNeighbor(2, _world[x + 1, y - 1]);
-                       _world[x + 1, y - 1].SetNeighbor(5, _world[x, y]);
-                       
-                       // Bottom Left of Even // Top Right of Odd
-                       _world[x,y].SetNeighbor(4, _world[x - 1, y - 1]);
-                       _world[x - 1, y - 1].SetNeighbor(1, _world[x, y]);
-                   }
+                    _world[x, y].SetNeighbor(0, _world[x, y + 1]);
+                    _world[x, y + 1].SetNeighbor(3, _world[x, y]);
                 }
+                
+                // Edge 3
+                if (y > 0)
+                {
+                    _world[x,y].SetNeighbor(3, _world[x , y - 1]);
+                    _world[x, y - 1].SetNeighbor(0, _world[x, y]);
+                }
+                
+                // Every Odd X Tile
+                if (x % 2 != 0)
+                {
+                    // Edge 1 
+                    if (x < _length - 1 && y < _height - 1)
+                    {
+                        _world[x, y].SetNeighbor(1, _world[x + 1, y + 1]);
+                        _world[x + 1, y + 1].SetNeighbor(4, _world[x, y]);
+                    }
+
+                    // Edge 2 
+                    if (x < _length - 1)
+                    {
+                        _world[x, y].SetNeighbor(2, _world[x + 1, y]);
+                        _world[x + 1, y].SetNeighbor(5, _world[x, y]);
+                    }
+
+                    // Edge 4
+                    if (x > 0)
+                    {
+                        _world[x,  y].SetNeighbor(4, _world[x - 1, y]);
+                        _world[x - 1, y].SetNeighbor(1, _world[x, y]);
+                    }
+
+                    // Edge 5
+                    if (x > 0 && y < _height - 1)
+                    {
+                        _world[x, y].SetNeighbor(5, _world[x - 1, y + 1]);
+                        _world[x - 1, y + 1].SetNeighbor(2, _world[x, y]);
+                    }
+                } 
             }
         }
     }
@@ -114,7 +130,7 @@ public class World : MonoBehaviour
         {
             if (_world[xPos, yPos].GetNeighbors()[x] is not null)
             {
-                output += "(" + _world[xPos, yPos].GetNeighbors()[x].GetXPos() + 
+                output += "Edge: " + x + " " + "(" + _world[xPos, yPos].GetNeighbors()[x].GetXPos() + 
                           "," + _world[xPos, yPos].GetNeighbors()[x].GetYPos() + ")";
                 
                 output += "\n";

--- a/Assets/Scripts/World.cs
+++ b/Assets/Scripts/World.cs
@@ -43,9 +43,52 @@ public class World : MonoBehaviour
         }
     }
 
+    /* Sets Tile Adjacency (neighbors) based on a Flat Top/Bottom hexagon  with an even-q orientation. */
     public void SetTileAdjacency()
     {
-        // Assign adjacent Tiles for every single Tile's edge.
+        for (int x = 0; x < _length - 1; x++)
+        {
+            for (int y = 0; y < _height - 1; y++)
+            {
+                // Top and Bottom of all Flat edges
+                _world[x, y].SetNeighbor(0, _world[x, y + 1]);
+                _world[x, y + 1].SetNeighbor(3, _world[x, y]);
+
+                // Check that X index is not out of bounds
+                if (x > 0 && x < _length && y > 0 && y < _height)
+                {
+                    // If X is Odd
+                   if (x % 2 != 0)
+                   {
+                       // Bottom Left of Odd X / Top Right of Even X
+                       _world[x, y].SetNeighbor(4, _world[x - 1, y]);
+                       _world[x - 1, y].SetNeighbor(1, _world[x, y]);
+                       
+                       // Bottom Right of Odd X / Top Left of Even X
+                       _world[x , y].SetNeighbor(2, _world[x + 1, y]);
+                       _world[x + 1, y].SetNeighbor(5, _world[x, y]);
+                   }
+                   else // If X is Even
+                   {
+                       // Top Left of Even X / Bottom Right of Odd X
+                       _world[x,y].SetNeighbor(5, _world[x - 1, y]);
+                       _world[x - 1, y].SetNeighbor(2, _world[x, y]);
+                       
+                       // Top Right of Even X / Bottom Left of Odd X
+                       _world[x,y].SetNeighbor(1, _world[x + 1, y]);
+                       _world[x + 1, y].SetNeighbor(4, _world[x, y]);
+                       
+                       // Bottom Right of Even // Top Left of Odd
+                       _world[x, y].SetNeighbor(2, _world[x + 1, y - 1]);
+                       _world[x + 1, y - 1].SetNeighbor(5, _world[x, y]);
+                       
+                       // Bottom Left of Even // Top Right of Odd
+                       _world[x,y].SetNeighbor(4, _world[x - 1, y - 1]);
+                       _world[x - 1, y - 1].SetNeighbor(1, _world[x, y]);
+                   }
+                }
+            }
+        }
     }
 
     /* Print the world to console. (Bad way to test but will do for now) */
@@ -61,5 +104,23 @@ public class World : MonoBehaviour
             worldString += "\n";
         }
         Debug.Log(worldString);
+    }
+
+    public void TestTileAdjacency(int xPos, int yPos)
+    {
+        string output = "Tile ("+xPos+","+yPos+") is adjacent to: " + "\n";
+
+        for (int x = 0; x < _world[xPos, yPos].GetNeighbors().Length; x++)
+        {
+            if (_world[xPos, yPos].GetNeighbors()[x] is not null)
+            {
+                output += "(" + _world[xPos, yPos].GetNeighbors()[x].GetXPos() + 
+                          "," + _world[xPos, yPos].GetNeighbors()[x].GetYPos() + ")";
+                
+                output += "\n";
+            }
+        }
+        
+        Debug.Log(output);
     }
 }

--- a/Assets/Scripts/World.cs
+++ b/Assets/Scripts/World.cs
@@ -46,14 +46,6 @@ public class World : MonoBehaviour
     /* Sets Tile Adjacency (neighbors) based on a Flat Top/Bottom hexagon  with an even-q orientation. */
     public void SetTileAdjacency()
     {
-        // Set the first Tile's neighbor's
-        _world[0,0].SetNeighbor(0, _world[0,1]);
-        _world[0,1].SetNeighbor(3, _world[0,0]);
-        
-        _world[0,0].SetNeighbor(1, _world[1,0]);
-        _world[1,0].SetNeighbor(4, _world[0,0]);
-        
-        
         for (int x = 0; x < _length; x++)
         {
             for (int y = 0; y < _height; y++)

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60
+  m_DefaultFrameRate: 60


### PR DESCRIPTION
Good news! Last night Jason the Great (or Weak) and I figured out one way to keep track of a hexagon tile's neighbors and on which edge they are. We pushed our code to John B's branch on the Github. 

Thanks to:
Jason
John
Timi

for helping us figure this problem out.

There are some very important notes about this implementation that you must know.
- It only works for flat top/bottom hexagons
- It only works for an [even-q grid vertical orientation](https://www.redblobgames.com/grids/hexagons/#coordinates). (shoves even columns down)
- It assigns a number to each edge of a hexagon.
- Each Tile obj has a Tile array called _neighbors. The index of the array corresponds with each side of a hexagon.  0 -> Top 3 -> Bottom

With this implementation we can do a lot of stuff, such as:
- Create a pathfinding algorithm by checking a Tile's neighbor Tiles.
- We can use the same logic and edge numbering to implement Rivers! Just tell a Tile on which edge(s) it has a river.
- We can use it for world generation by having tile spread certain terrain or features to its neighbors.
